### PR TITLE
Fixed an issue with encumbrance on actor-unlinked tokens

### DIFF
--- a/src/scripts/modules.mjs
+++ b/src/scripts/modules.mjs
@@ -220,7 +220,8 @@ export const readyHooks = async () => {
   };
 
   Hooks.on("renderActorSheet", async function (actorSheet, htmlElement, actorObject) {
-    const actorEntityTmp = game.actors?.get(actorObject.actor._id); //duplicate(actorEntity) ;
+    // Can't necessarily go straight to the supplied object, as it may not have the proper type if the actor is an unlinked Token actor
+    const actorEntityTmp = (actorObject && actorObject.type) ? actorObject : actorObject.actor;
     if (isEnabledActorType(actorEntityTmp)) {
       const htmlElementEncumbranceVariant = htmlElement.find(".encumbrance").addClass("encumbrance-variant");
       //@ts-ignore
@@ -406,7 +407,7 @@ export const readyHooks = async () => {
         doTheUpdate = true;
         noActiveEffect = false;
       }
-      // For our purpose we filter only the invenctory-plus modifier action
+      // For our purpose we filter only the inventory-plus modifier action
       if (invPlusActive && update?.flags && hasProperty(update, `flags.${CONSTANTS.INVENTORY_PLUS_MODULE_NAME}`)) {
         doTheUpdate = true;
         noActiveEffect = false;


### PR DESCRIPTION
The previous lookup of the actor based on the hook-supplied `actorObject` fetched the game actor by its ID. In most cases, this works fine...except when a token on a map has been unlinked from its parent actor, in which case its inventory may differ from what the "real" actor's inventory has on it. The net result is that the actor represents a weight value that does not match what they are actually carrying (because the weight value was showing what their "real" parent had).

This tweak instead checks to see if the supplied `actorObject` has the `type` property, indicative of a "true" actor (and the property `isEnabledActorType()` depends on, of course!), and otherwise supplies the `actor` property of the `actorObject`, which should correspond to the unlinked pseudo-actor represented on the sheet.